### PR TITLE
Fixing error with JSON string

### DIFF
--- a/CSharp/OpenTraceability/Queries/MasterDataResolver.cs
+++ b/CSharp/OpenTraceability/Queries/MasterDataResolver.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http.Json;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -279,7 +280,11 @@ namespace OpenTraceability.Queries
 
                             if (response.IsSuccessStatusCode)
                             {
-                                string json = await response.Content.ReadAsStringAsync();
+                                var json = (await response.Content.ReadFromJsonAsync<object>())?.ToString();
+                            
+                                if (json is null) 
+                                    throw new NullReferenceException("Error parsing the digital link response: JSON value is null");
+                                
                                 var item = OpenTraceabilityMappers.MasterData.GS1WebVocab.Map(type, json);
                                 if (item != null)
                                 {


### PR DESCRIPTION
When using the MasterDataResolver in wholechain, we ran in the following issue:

```
Newtonsoft.Json.JsonReaderException: Error reading JObject from JsonReader. Current JsonReader item is not an object: String. Path '', line 1, position 1165.
   at Newtonsoft.Json.Linq.JObject.Load(JsonReader reader, JsonLoadSettings settings)
   at Newtonsoft.Json.Linq.JObject.Parse(String json, JsonLoadSettings settings)
   at Newtonsoft.Json.Linq.JObject.Parse(String json)
   at OpenTraceability.Mappers.MasterData.GS1VocabJsonMapper.Map(Type type, String value)
   at OpenTraceability.Queries.MasterDataResolver.ResolveMasterDataItem(Type type, DigitalLinkQueryOptions options, String relativeURL, HttpClient httpClient)
```


It seems that it's keeping the \r\n instead of converting to JSON. The issue happens on the line below on the GS1VocabJsonMapper:

`JObject json = JObject.Parse(value);`

It was fixed by reading the response from the digital link as JSON.
