### PR TITLE
Add a farm harvest object event

### DIFF
--- a/CSharp/OpenTraceability.GDST/Events/GDSTFarmHarvestObjectEvent.cs
+++ b/CSharp/OpenTraceability.GDST/Events/GDSTFarmHarvestObjectEvent.cs
@@ -1,0 +1,28 @@
+﻿using OpenTraceability.Models.Events;
+using OpenTraceability.Models.Identifiers;
+using OpenTraceability.Utility.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenTraceability.GDST.Events
+{
+    public class GDSTFarmHarvestObjectEvent : ObjectEvent<GDSTILMD>, IGDSTEvent
+    {
+        [OpenTraceability(Constants.GDST_NAMESPACE, "productOwner")]
+        [OpenTraceabilityJson("gdst:productOwner")]
+        public PGLN? ProductOwner { get; set; }
+
+        [OpenTraceability(Constants.GDST_NAMESPACE, "humanWelfarePolicy")]
+        [OpenTraceabilityJson("gdst:humanWelfarePolicy")]
+        public string? HumanWelfarePolicy { get; set; }
+
+        public GDSTFarmHarvestObjectEvent()
+        {
+            this.BusinessStep = new Uri("urn:gdst:bizStep:farmHarvest");
+            this.Action = EventAction.ADD;
+        }
+    }
+}

--- a/CSharp/OpenTraceability.GDST/Setup.cs
+++ b/CSharp/OpenTraceability.GDST/Setup.cs
@@ -29,6 +29,7 @@ namespace OpenTraceability.GDST
                     OpenTraceability.Setup.RegisterEventProfile(new OpenTraceabilityEventProfile(typeof(GDSTLandingEvent), EventType.ObjectEvent, "urn:gdst:bizstep:landing", Models.Events.EventAction.OBSERVE));
                     OpenTraceability.Setup.RegisterEventProfile(new OpenTraceabilityEventProfile(typeof(GDSTHatchingEvent), EventType.ObjectEvent, "urn:gdst:bizstep:hatching", Models.Events.EventAction.ADD));
                     OpenTraceability.Setup.RegisterEventProfile(new OpenTraceabilityEventProfile(typeof(GDSTFarmHarvestEvent), EventType.TransformationEvent, "urn:gdst:bizstep:farmharvest"));
+                    OpenTraceability.Setup.RegisterEventProfile(new OpenTraceabilityEventProfile(typeof(GDSTFarmHarvestObjectEvent), EventType.ObjectEvent, "urn:gdst:bizstep:farmharvest"));
                     OpenTraceability.Setup.RegisterEventProfile(new OpenTraceabilityEventProfile(typeof(GDSTProcessingEvent), EventType.TransformationEvent, "urn:epcglobal:cbv:bizstep:commissioning"));
                     OpenTraceability.Setup.RegisterEventProfile(new OpenTraceabilityEventProfile(typeof(GDSTProcessingEvent), EventType.TransformationEvent, "https://ref.gs1.org/cbv/BizStep-commissioning"));
                     OpenTraceability.Setup.RegisterEventProfile(new OpenTraceabilityEventProfile(typeof(GDSTReceiveEvent), EventType.ObjectEvent, "urn:epcglobal:cbv:bizstep:receiving", Models.Events.EventAction.OBSERVE));

--- a/CSharp/OpenTraceability.GDST/Setup.cs
+++ b/CSharp/OpenTraceability.GDST/Setup.cs
@@ -29,7 +29,7 @@ namespace OpenTraceability.GDST
                     OpenTraceability.Setup.RegisterEventProfile(new OpenTraceabilityEventProfile(typeof(GDSTLandingEvent), EventType.ObjectEvent, "urn:gdst:bizstep:landing", Models.Events.EventAction.OBSERVE));
                     OpenTraceability.Setup.RegisterEventProfile(new OpenTraceabilityEventProfile(typeof(GDSTHatchingEvent), EventType.ObjectEvent, "urn:gdst:bizstep:hatching", Models.Events.EventAction.ADD));
                     OpenTraceability.Setup.RegisterEventProfile(new OpenTraceabilityEventProfile(typeof(GDSTFarmHarvestEvent), EventType.TransformationEvent, "urn:gdst:bizstep:farmharvest"));
-                    OpenTraceability.Setup.RegisterEventProfile(new OpenTraceabilityEventProfile(typeof(GDSTFarmHarvestObjectEvent), EventType.ObjectEvent, "urn:gdst:bizstep:farmharvest"));
+                    OpenTraceability.Setup.RegisterEventProfile(new OpenTraceabilityEventProfile(typeof(GDSTFarmHarvestObjectEvent), EventType.ObjectEvent, "urn:gdst:bizstep:farmharvest", Models.Events.EventAction.ADD));
                     OpenTraceability.Setup.RegisterEventProfile(new OpenTraceabilityEventProfile(typeof(GDSTProcessingEvent), EventType.TransformationEvent, "urn:epcglobal:cbv:bizstep:commissioning"));
                     OpenTraceability.Setup.RegisterEventProfile(new OpenTraceabilityEventProfile(typeof(GDSTProcessingEvent), EventType.TransformationEvent, "https://ref.gs1.org/cbv/BizStep-commissioning"));
                     OpenTraceability.Setup.RegisterEventProfile(new OpenTraceabilityEventProfile(typeof(GDSTReceiveEvent), EventType.ObjectEvent, "urn:epcglobal:cbv:bizstep:receiving", Models.Events.EventAction.OBSERVE));

--- a/CSharp/OpenTraceability.Tests/Data/farm_harvest_event_object.jsonld
+++ b/CSharp/OpenTraceability.Tests/Data/farm_harvest_event_object.jsonld
@@ -1,0 +1,117 @@
+{
+  "@context": [
+    "https://ref.gs1.org/standards/epcis/epcis-context.jsonld",
+    {
+      "gdst": "https://traceability-dialogue.org/epcis"
+    }
+  ],
+  "type": "EPCISDocument",
+  "creationDate": "2024-11-25T21:21:59.1838429+00:00",
+  "schemaVersion": "2.0",
+  "epcisHeader": {
+    "epcisMasterData": {
+      "vocabularyList": [
+        {
+          "type": "urn:epcglobal:epcis:vtype:EPCClass",
+          "vocabularyElementList": [
+            {
+              "id": "urn:gdst:example.org:product:class:test.test",
+              "attributes": [
+                {
+                  "id": "urn:epcglobal:cbv:mda#descriptionShort",
+                  "attribute": "test"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "urn:epcglobal:epcis:vtype:Location",
+          "vocabularyElementList": [
+            {
+              "id": "urn:gdst:example.org:location:loc:test.test",
+              "attributes": [
+                {
+                  "id": "urn:epcglobal:cbv:mda#name",
+                  "attribute": "test"
+                },
+                {
+                  "id": "urn:epcglobal:cbv:mda#contact",
+                  "attribute": "test"
+                },
+                {
+                  "id": "urn:epcglobal:cbv:mda#email",
+                  "attribute": "test"
+                },
+                {
+                  "id": "urn:epcglobal:cbv:mda#streetAddressOne",
+                  "attribute": "test"
+                },
+                {
+                  "id": "urn:epcglobal:cbv:mda#city",
+                  "attribute": "test"
+                },
+                {
+                  "id": "urn:epcglobal:cbv:mda#state",
+                  "attribute": "test"
+                },
+                {
+                  "id": "urn:epcglobal:cbv:mda#countryCode",
+                  "attribute": "BR"
+                },
+                {
+                  "id": "urn:epcglobal:cbv:mda#latitude",
+                  "attribute": "0"
+                },
+                {
+                  "id": "urn:epcglobal:cbv:mda#longitude",
+                  "attribute": "0"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "urn:epcglobal:epcis:vtype:Party",
+          "vocabularyElementList": [
+            {
+              "id": "urn:gdst:example.org:party:test.0",
+              "attributes": [
+                {
+                  "id": "urn:epcglobal:cbv:mda#name",
+                  "attribute": "test"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "epcisBody": {
+    "eventList": [
+      {
+        "type": "ObjectEvent",
+        "eventTime": "2024-11-11T08:00:00.0000000+00:00",
+        "recordTime": "2024-11-14T15:15:50.6724380+00:00",
+        "eventTimeZoneOffset": "+00:00",
+        "eventID": "urn:uuid:00000000-0000-0000-0000-000000000000",
+        "epcList": [],
+        "action": "ADD",
+        "bizStep": "urn:gdst:bizStep:farmHarvest",
+        "disposition": "active",
+        "bizLocation": {
+          "id": "urn:gdst:example.org:location:loc:test.test"
+        },
+        "quantityList": [
+          {
+            "epcClass": "urn:gdst:example.org:product:lot:class:test.test.test",
+            "quantity": 1
+          }
+        ],
+        "gdst:productOwner": "urn:gdst:example.org:party:test.0",
+        "cbvmda:informationProvider": "urn:gdst:example.org:party:test.0"
+      }
+    ]
+  }
+}

--- a/CSharp/OpenTraceability.Tests/Events/EPCISDocumentTests.cs
+++ b/CSharp/OpenTraceability.Tests/Events/EPCISDocumentTests.cs
@@ -131,6 +131,7 @@ namespace OpenTraceability.Tests.Events
         [TestCase("transaction_event_all_possible_fields.jsonld")]
         [TestCase("transformation_event_all_possible_fields.jsonld")]
         [TestCase("wholechainbug01.jsonld")]
+        [TestCase("farm_harvest_event_object.jsonld")]
         public void JSONLD(string file)
         {
             // read object events from test data specified in the file argument

--- a/CSharp/OpenTraceability.Tests/OpenTraceability.Tests.csproj
+++ b/CSharp/OpenTraceability.Tests/OpenTraceability.Tests.csproj
@@ -19,6 +19,7 @@
 		<None Remove="data\EPCISQUERYDOCUMENT_with_errorDeclarations.jsonld" />
 		<None Remove="Data\EPCISQueryDocument_with_masterdata.jsonld" />
 		<None Remove="Data\epc_tests.json" />
+		<None Remove="data\farm_harvest_event_object.jsonld" />
 		<None Remove="Data\gdst_data_withmasterdata.jsonld" />
 		<None Remove="Data\gdst_extensions_01.xml" />
 		<None Remove="Data\gdst_extensions_02.xml" />


### PR DESCRIPTION
Add a farm harvest object event and associated test case. Does not rename the original farm harvest to prevent breaking changes in other applications consuming this package. credit to bcamba for providing this improvement.