### PR TITLE
Allow slash and % characters in urns

### DIFF
--- a/CSharp/OpenTraceability.Tests/Data/epc_tests.json
+++ b/CSharp/OpenTraceability.Tests/Data/epc_tests.json
@@ -16,5 +16,17 @@
         "type": "Class",
         "gtin": "urn:gdst:example.org:product:class:processor.2u",
         "lotOrSerial": "v1-0122-2022"
+    },
+    {
+        "epc": "urn:gdst:example.org:product:lot:class:company.product.something/more/and/more",
+        "type": "Class",
+        "gtin": "urn:gdst:example.org:product:class:company.product",
+        "lotOrSerial": "something/more/and/more"
+    },
+    {
+        "epc": "urn:gdst:example.org:product:lot:class:company.pr%c3%b3d%c3%bact%c3%a9.something",
+        "type": "Class",
+        "gtin": "urn:gdst:example.org:product:class:company.pr%c3%b3d%c3%bact%c3%a9",
+        "lotOrSerial": "something"
     }
 ]

--- a/CSharp/OpenTraceability/Utility/StringExtensions.cs
+++ b/CSharp/OpenTraceability/Utility/StringExtensions.cs
@@ -23,7 +23,7 @@ namespace OpenTraceability.Utility
             }
         }
 
-        private static Regex _isURICompatibleCharsRegex = new Regex(@"(.*[^._\-:*0-9A-Za-z])", RegexOptions.Compiled);
+        private static Regex _isURICompatibleCharsRegex = new Regex(@"(.*[^._\-/%:*0-9A-Za-z])", RegexOptions.Compiled);
 
         /// <summary>
         /// Tries and converts a string value into a DateTimeOffset using the ISO standard format. If it fails, it returns null.


### PR DESCRIPTION
Allow forward slash "/" and percent "%" characters in urns.

These should be valid according to RFC 8141