### PR TITLE
Error Declaration: Fix on nullable properties

### DIFF
--- a/CSharp/OpenTraceability/Models/Events/ErrorDeclaration.cs
+++ b/CSharp/OpenTraceability/Models/Events/ErrorDeclaration.cs
@@ -1,10 +1,8 @@
 ﻿using OpenTraceability.Interfaces;
-using OpenTraceability.Utility;
 using OpenTraceability.Utility.Attributes;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using JetBrains.Annotations;
 
 namespace OpenTraceability.Models.Events
 {

--- a/CSharp/OpenTraceability/Models/Events/ErrorDeclaration.cs
+++ b/CSharp/OpenTraceability/Models/Events/ErrorDeclaration.cs
@@ -4,6 +4,7 @@ using OpenTraceability.Utility.Attributes;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using JetBrains.Annotations;
 
 namespace OpenTraceability.Models.Events
 {
@@ -22,10 +23,10 @@ namespace OpenTraceability.Models.Events
     {
         [OpenTraceabilityJson("reason")]
         [OpenTraceability("@type")]
-        public Uri Reason { get; set; }
+        public Uri? Reason { get; set; }
 
         [OpenTraceability("declarationTime")]
-        public DateTimeOffset? DeclarationTime { get; set; }
+        public DateTimeOffset DeclarationTime { get; set; }
 
         [OpenTraceabilityArray("correctiveEventID")]
         [OpenTraceability("correctiveEventIDs")]

--- a/CSharp/OpenTraceability/OpenTraceability.csproj
+++ b/CSharp/OpenTraceability/OpenTraceability.csproj
@@ -13,6 +13,8 @@
 		<RepositoryUrl>https://github.com/ift-gftc/opentraceability</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>epcis;open;traceability;ift;gdst</PackageTags>
+		<NullableReferenceTypes>true</NullableReferenceTypes>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
On page 43 of the document it says that the Reason is optional and the DeclarationTime is required.

https://www.gs1.org/sites/default/files/docs/epc/EPCIS-Standard-1.2-r-2016-09-29.pdf

<img width="683" alt="image" src="https://github.com/user-attachments/assets/bc045b5f-ea42-4b3e-b900-c6cd6a637d1b" />

