### PR TITLE
Update json mapper method from internal to public

### DIFF
--- a/CSharp/OpenTraceability/Mappers/EPCIS/JSON/EPCISDocumentBaseJsonMapper.cs
+++ b/CSharp/OpenTraceability/Mappers/EPCIS/JSON/EPCISDocumentBaseJsonMapper.cs
@@ -210,7 +210,7 @@ namespace OpenTraceability.Mappers.EPCIS.JSON
             }
         }
 
-        internal static Type GetEventTypeFromProfile(JObject jEvent)
+        public static Type GetEventTypeFromProfile(JObject jEvent)
         {
             Enum.TryParse<EventAction>(jEvent["action"]?.ToString(), out var action);
             string bizStep = jEvent["bizStep"]?.ToString();


### PR DESCRIPTION
Make the geteventtypefromprofile method on the base json mapper method public.